### PR TITLE
Added setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     license='Apache',
     keywords='Trade API for Robinhood',
     packages=['robinhood'],
+    package_data={
+        'robinhood': ['certs/*']
+    },
     install_requires=[
         'requests >= 2.18.4',
         'python-dateutil >= 2.6.1',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+"""setup.py for core library"""
+
+from setuptools import setup
+
+__version__ = '1.0.0'
+
+setup(
+    name='robinhood-python',
+    author='Matt Strum',
+    url='https://github.com/mstrum/robinhood-python',
+    version=__version__,
+    license='Apache',
+    keywords='Trade API for Robinhood',
+    packages=['robinhood'],
+    install_requires=[
+        'requests >= 2.18.4',
+        'python-dateutil >= 2.6.1',
+        'pytz >= 2018.3'
+    ],
+    extras_require={
+        'dev': [
+            'flake8 >= 3.5.0'
+        ]
+    }
+)


### PR DESCRIPTION
Allows package to be installed using `pip install .` or `pip install -r requirements.txt` if the `requirements.txt` file has a line pointing to a directory in the local filesystem (e.g., `./robinhood-python`).