### PR TITLE
Satisfy case-sensitivity for getting nonzero options positions

### DIFF
--- a/robinhood/RobinhoodClient.py
+++ b/robinhood/RobinhoodClient.py
@@ -2428,7 +2428,7 @@ class RobinhoodClient:
     """
     params = {}
     if not include_old:
-      params['nonzero'] = 'true'
+      params['nonzero'] = 'True'
     response = self._get_session(API, authed=True).get(API_HOST + 'options/positions/', params=params)
     _raise_on_error(response)
     response_json = response.json()


### PR DESCRIPTION
The `nonzero` parameter for the `/options/positions` endpoint seems to be case-sensitive (which is funny, because the equities equivalent is not case-sensitive). This change simply complies with the required case.